### PR TITLE
feat: add Docker-based build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS
+
+Welcome to the **openapi-desktop** repository. This project packages Swagger UI into an Electron desktop application and builds distributable artifacts for Linux, Windows and macOS.
+
+## Getting Started
+- Use Node.js 18+ or rely on the provided Dockerfile.
+- Install dependencies with `npm ci`.
+- Use the Makefile targets (`build-linux`, `build-windows`, `build-macos`) for platform builds.
+
+## Development Guidelines
+- Follow two-space indentation and run Prettier when available: `npx prettier -w`.
+- Keep commits small and use [Conventional Commits](https://www.conventionalcommits.org/) prefixes (`feat:`, `fix:`, `docs:` ...).
+- Update tests and documentation alongside code changes.
+- Avoid committing build artifacts or `node_modules`.
+- Use ripgrep (`rg`) instead of recursive `ls` or `grep` for searches.
+
+## Required Checks
+- Run `npm test` before pushing changes.
+- If you modify build scripts or Docker setup, run `docker build -t openapi-desktop-builder .` to verify the image builds.
+- Note any failing checks in your PR description.
+
+## Pull Requests
+- Summarize your changes and testing steps in the PR description.
+- Ensure the working tree is clean before committing.
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM electronuserland/builder:latest
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+ENTRYPOINT ["npm", "run"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.RECIPEPREFIX := >
+IMAGE_NAME=openapi-desktop-builder
+
+.PHONY: docker-build build-linux build-windows build-macos
+
+docker-build:
+>docker build -t $(IMAGE_NAME) .
+
+build-linux: docker-build
+>docker run --rm -v $(PWD)/dist:/app/dist $(IMAGE_NAME) build:linux
+
+build-windows: docker-build
+>docker run --rm -v $(PWD)/dist:/app/dist $(IMAGE_NAME) build:win
+
+build-macos: docker-build
+>docker run --rm -v $(PWD)/dist:/app/dist $(IMAGE_NAME) build:mac

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 This is a minimal Electron application that bundles [Swagger UI](https://github.com/swagger-api/swagger-ui) to view OpenAPI specifications.
 
 ## Prerequisites
-- [Node.js](https://nodejs.org/) 18+
+- [Node.js](https://nodejs.org/) 18+ (for local builds)
+- [Docker](https://www.docker.com/) for containerized builds
 
 ## Install
 ```bash
@@ -33,3 +34,27 @@ The project uses [electron-builder](https://www.electron.build/) to package bina
 
 ## Testing
 No automated tests are included yet.
+
+## Build with Docker
+If you prefer not to install Node.js locally, you can build the app inside Docker.
+
+First build the image:
+```bash
+make docker-build
+```
+
+Then build for your platform:
+- **Linux**:
+  ```bash
+  make build-linux
+  ```
+- **Windows**:
+  ```bash
+  make build-windows
+  ```
+- **macOS**:
+  ```bash
+  make build-macos
+  ```
+
+The resulting files will appear under `dist/linux`, `dist/windows` and `dist/macos` respectively.

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "build:win": "electron-builder --win",
-    "build:linux": "electron-builder --linux",
-    "build:mac": "electron-builder --mac",
+    "build:win": "electron-builder --win --config.directories.output=dist/windows",
+    "build:linux": "electron-builder --linux --config.directories.output=dist/linux",
+    "build:mac": "electron-builder --mac --config.directories.output=dist/macos",
     "test": "echo 'No tests'"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add Dockerfile and Makefile for containerized builds
- document building with Docker and dist directories for each platform
- configure build scripts to output per-platform folders
- add AGENTS.md with repository development guidelines

## Testing
- `npm test`
- `docker build -t openapi-desktop-builder .` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68aedc7a5fe48324bc93ebf2b0dd822e