### PR TITLE
fix: build linux targets sequentially

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "electron .",
     "build:win": "electron-builder --win --config.directories.output=dist/windows",
-    "build:linux": "electron-builder --linux --config.directories.output=dist/linux",
+    "build:linux": "electron-builder --linux AppImage --config.directories.output=dist/linux && electron-builder --linux snap --config.directories.output=dist/linux",
     "build:mac": "electron-builder --mac --config.directories.output=dist/macos",
     "test": "echo 'No tests'"
   },


### PR DESCRIPTION
## Summary
- build linux AppImage and Snap sequentially to avoid cache race

## Testing
- `npm test`
- `npm run build:linux`
- `docker build -t openapi-desktop-builder .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aee5e45ca48324a9f29c75fa5d5578