### PR TITLE
feat: set favicon as app icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,24 +1,29 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta charset="UTF-8" />
-  <title>Swagger UI Electron</title>
-  <link rel="stylesheet" type="text/css" href="node_modules/swagger-ui-dist/swagger-ui.css" />
-</head>
-<body>
-  <div id="swagger-ui"></div>
-  <script src="node_modules/swagger-ui-dist/swagger-ui-bundle.js"></script>
-  <script src="node_modules/swagger-ui-dist/swagger-ui-standalone-preset.js"></script>
-  <script>
-    window.addEventListener('DOMContentLoaded', () => {
-      const ui = SwaggerUIBundle({
-        url: 'https://petstore.swagger.io/v2/swagger.json',
-        dom_id: '#swagger-ui',
-        presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
-        layout: 'StandaloneLayout'
+  <head>
+    <meta charset="UTF-8" />
+    <title>Swagger UI Electron</title>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="node_modules/swagger-ui-dist/swagger-ui.css"
+    />
+    <link rel="icon" type="image/png" href="favicon.png" />
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="node_modules/swagger-ui-dist/swagger-ui-bundle.js"></script>
+    <script src="node_modules/swagger-ui-dist/swagger-ui-standalone-preset.js"></script>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const ui = SwaggerUIBundle({
+          url: "https://petstore.swagger.io/v2/swagger.json",
+          dom_id: "#swagger-ui",
+          presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+          layout: "StandaloneLayout",
+        });
+        window.ui = ui;
       });
-      window.ui = ui;
-    });
-  </script>
-</body>
+    </script>
+  </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,31 +1,35 @@
-const { app, BrowserWindow } = require('electron');
-const path = require('path');
+const { app, BrowserWindow } = require("electron");
+const path = require("path");
 
 function createWindow() {
   const win = new BrowserWindow({
     width: 1024,
     height: 768,
+    icon: path.join(__dirname, "favicon.png"),
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: false,
     },
   });
 
-  win.loadFile('index.html');
+  win.loadFile("index.html");
 }
 
 app.whenReady().then(() => {
+  if (process.platform === "darwin") {
+    app.dock.setIcon(path.join(__dirname, "favicon.png"));
+  }
   createWindow();
 
-  app.on('activate', () => {
+  app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       createWindow();
     }
   });
 });
 
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") {
     app.quit();
   }
 });

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "electron-builder": "^26.0.12"
   },
   "build": {
-    "appId": "com.example.openapi"
+    "appId": "com.example.openapi",
+    "icon": "favicon.png"
   }
 }


### PR DESCRIPTION
## Summary
- use `favicon.png` for window and dock icons
- add favicon link in HTML and configure electron-builder to package it

## Testing
- `npx prettier -w main.js index.html package.json`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeeb7f45cc8324897032282d3b43dd