### PR TITLE
feat: use swagger-editor instead of swagger-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,26 @@
 # OpenAPI Desktop
 
-This is a minimal Electron application that bundles [Swagger UI](https://github.com/swagger-api/swagger-ui) to view OpenAPI specifications.
+This is a minimal Electron application that bundles [Swagger Editor](https://github.com/swagger-api/swagger-editor) to edit OpenAPI specifications.
 
 ## Prerequisites
+
 - [Node.js](https://nodejs.org/) 18+ (for local builds)
 - [Docker](https://www.docker.com/) for containerized builds
 
 ## Install
+
 ```bash
 npm install
 ```
 
 ## Run in development
+
 ```bash
 npm start
 ```
 
 ## Build distributables
+
 The project uses [electron-builder](https://www.electron.build/) to package binaries for different platforms.
 
 - **Windows**:
@@ -33,17 +37,21 @@ The project uses [electron-builder](https://www.electron.build/) to package bina
   ```
 
 ## Testing
+
 No automated tests are included yet.
 
 ## Build with Docker
+
 If you prefer not to install Node.js locally, you can build the app inside Docker.
 
 First build the image:
+
 ```bash
 make docker-build
 ```
 
 Then build for your platform:
+
 - **Linux**:
   ```bash
   make build-linux

--- a/index.html
+++ b/index.html
@@ -2,27 +2,27 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Swagger UI Electron</title>
+    <title>Swagger Editor Electron</title>
     <link
       rel="stylesheet"
       type="text/css"
-      href="node_modules/swagger-ui-dist/swagger-ui.css"
+      href="node_modules/swagger-editor-dist/swagger-editor.css"
     />
     <link rel="icon" type="image/png" href="favicon.png" />
   </head>
   <body>
-    <div id="swagger-ui"></div>
-    <script src="node_modules/swagger-ui-dist/swagger-ui-bundle.js"></script>
-    <script src="node_modules/swagger-ui-dist/swagger-ui-standalone-preset.js"></script>
+    <div id="swagger-editor"></div>
+    <script src="node_modules/swagger-editor-dist/swagger-editor-bundle.js"></script>
+    <script src="node_modules/swagger-editor-dist/swagger-editor-standalone-preset.js"></script>
     <script>
       window.addEventListener("DOMContentLoaded", () => {
-        const ui = SwaggerUIBundle({
+        const editor = SwaggerEditorBundle({
           url: "https://petstore.swagger.io/v2/swagger.json",
-          dom_id: "#swagger-ui",
-          presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+          dom_id: "#swagger-editor",
           layout: "StandaloneLayout",
+          presets: [SwaggerEditorStandalonePreset],
         });
-        window.ui = ui;
+        window.editor = editor;
       });
     </script>
   </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "swagger-ui-dist": "^5.27.1"
+        "swagger-editor-dist": "^4.14.6"
       },
       "devDependencies": {
         "electron": "^37.3.1",
@@ -4583,10 +4583,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/swagger-ui-dist": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.27.1.tgz",
-      "integrity": "sha512-oGtpYO3lnoaqyGtlJalvryl7TwzgRuxpOVWqEHx8af0YXI+Kt+4jMpLdgMtMcmWmuQ0QTCHLKExwrBFMSxvAUA==",
+    "node_modules/swagger-editor-dist": {
+      "version": "4.14.6",
+      "resolved": "https://registry.npmjs.org/swagger-editor-dist/-/swagger-editor-dist-4.14.6.tgz",
+      "integrity": "sha512-QeiGjUWGcTJ4uBy4U+uf0Vpf7YNHXBzhI/4UGJA5fVBh31nTu2jNXZKVNqMZan/EvCTTQSYkL0wrJBHzOjFjgA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-desktop",
   "version": "1.0.0",
-  "description": "Desktop Electron app with Swagger UI",
+  "description": "Desktop Electron app with Swagger Editor",
   "main": "main.js",
   "scripts": {
     "start": "electron .",
@@ -15,7 +15,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "swagger-ui-dist": "^5.27.1"
+    "swagger-editor-dist": "^4.14.6"
   },
   "devDependencies": {
     "electron": "^37.3.1",


### PR DESCRIPTION
## Summary
- switch app to Swagger Editor for editing specs
- update dependencies and documentation for Swagger Editor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aef003e64c8324a9d7fa55c4125a70