### PR TITLE
feat: use swagger-editor and load spec from cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,12 @@ docker-build:
 
 build-linux: docker-build
 >docker run --rm -v $(PWD)/dist:/app/dist $(IMAGE_NAME) build:linux
+>echo "Binary now available in dist/linux"
 
 build-windows: docker-build
 >docker run --rm -v $(PWD)/dist:/app/dist $(IMAGE_NAME) build:win
+>echo "Binary now available in dist/windows"
 
 build-macos: docker-build
 >docker run --rm -v $(PWD)/dist:/app/dist $(IMAGE_NAME) build:mac
+>echo "Binary now available in dist/macos"

--- a/README.md
+++ b/README.md
@@ -1,22 +1,38 @@
 # OpenAPI Desktop
 
-This is a minimal Electron application that bundles [Swagger UI](https://github.com/swagger-api/swagger-ui) to view OpenAPI specifications.
+This is a minimal Electron application that bundles [Swagger Editor](https://github.com/swagger-api/swagger-editor) to edit OpenAPI specifications.
 
 ## Prerequisites
+
 - [Node.js](https://nodejs.org/) 18+ (for local builds)
 - [Docker](https://www.docker.com/) for containerized builds
 
 ## Install
+
 ```bash
 npm install
 ```
 
 ## Run in development
+
 ```bash
 npm start
 ```
 
+To open a specific OpenAPI file, pass the path after `--`:
+
+```bash
+npm start -- path/to/spec.yaml
+```
+
+Packaged binaries also accept a file path as the first argument:
+
+```bash
+openapi-desktop path/to/spec.yaml
+```
+
 ## Build distributables
+
 The project uses [electron-builder](https://www.electron.build/) to package binaries for different platforms.
 
 - **Windows**:
@@ -33,17 +49,21 @@ The project uses [electron-builder](https://www.electron.build/) to package bina
   ```
 
 ## Testing
+
 No automated tests are included yet.
 
 ## Build with Docker
+
 If you prefer not to install Node.js locally, you can build the app inside Docker.
 
 First build the image:
+
 ```bash
 make docker-build
 ```
 
 Then build for your platform:
+
 - **Linux**:
   ```bash
   make build-linux

--- a/index.html
+++ b/index.html
@@ -2,27 +2,39 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Swagger UI Electron</title>
+    <title>OpenAPI Desktop</title>
     <link
       rel="stylesheet"
       type="text/css"
-      href="node_modules/swagger-ui-dist/swagger-ui.css"
+      href="node_modules/swagger-editor-dist/swagger-editor.css"
     />
     <link rel="icon" type="image/png" href="favicon.png" />
   </head>
   <body>
-    <div id="swagger-ui"></div>
-    <script src="node_modules/swagger-ui-dist/swagger-ui-bundle.js"></script>
-    <script src="node_modules/swagger-ui-dist/swagger-ui-standalone-preset.js"></script>
+    <div id="swagger-editor"></div>
+    <script src="node_modules/swagger-editor-dist/swagger-editor-bundle.js"></script>
+    <script src="node_modules/swagger-editor-dist/swagger-editor-standalone-preset.js"></script>
     <script>
       window.addEventListener("DOMContentLoaded", () => {
-        const ui = SwaggerUIBundle({
-          url: "https://petstore.swagger.io/v2/swagger.json",
-          dom_id: "#swagger-ui",
-          presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+        const params = new URLSearchParams(window.location.search);
+        const file = params.get("file");
+        const options = {
+          dom_id: "#swagger-editor",
           layout: "StandaloneLayout",
-        });
-        window.ui = ui;
+          presets: [SwaggerEditorStandalonePreset],
+        };
+        if (file) {
+          const fs = require("fs");
+          try {
+            options.spec = fs.readFileSync(file, "utf8");
+          } catch (err) {
+            console.error("Failed to load file", err);
+          }
+        } else {
+          options.url = "https://petstore.swagger.io/v2/swagger.json";
+        }
+        const editor = SwaggerEditorBundle(options);
+        window.editor = editor;
       });
     </script>
   </body>

--- a/main.js
+++ b/main.js
@@ -1,18 +1,27 @@
 const { app, BrowserWindow } = require("electron");
 const path = require("path");
 
+const specPath = process.argv.slice(2)[0];
+
 function createWindow() {
   const win = new BrowserWindow({
     width: 1024,
     height: 768,
     icon: path.join(__dirname, "favicon.png"),
+    title: "OpenAPI Desktop",
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: false,
     },
   });
 
-  win.loadFile("index.html");
+  const indexPath = path.join(__dirname, "index.html");
+  if (specPath) {
+    win.loadFile(indexPath, { query: { file: path.resolve(specPath) } });
+  } else {
+    win.loadFile(indexPath);
+  }
+  win.setTitle("OpenAPI Desktop");
 }
 
 app.whenReady().then(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "swagger-ui-dist": "^5.27.1"
+        "swagger-editor-dist": "^4.14.6"
       },
       "devDependencies": {
         "electron": "^37.3.1",
@@ -4583,10 +4583,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/swagger-ui-dist": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.27.1.tgz",
-      "integrity": "sha512-oGtpYO3lnoaqyGtlJalvryl7TwzgRuxpOVWqEHx8af0YXI+Kt+4jMpLdgMtMcmWmuQ0QTCHLKExwrBFMSxvAUA==",
+    "node_modules/swagger-editor-dist": {
+      "version": "4.14.6",
+      "resolved": "https://registry.npmjs.org/swagger-editor-dist/-/swagger-editor-dist-4.14.6.tgz",
+      "integrity": "sha512-QeiGjUWGcTJ4uBy4U+uf0Vpf7YNHXBzhI/4UGJA5fVBh31nTu2jNXZKVNqMZan/EvCTTQSYkL0wrJBHzOjFjgA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-desktop",
   "version": "1.0.0",
-  "description": "Desktop Electron app with Swagger UI",
+  "description": "Desktop Electron app with Swagger Editor",
   "main": "main.js",
   "scripts": {
     "start": "electron .",
@@ -15,7 +15,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "swagger-ui-dist": "^5.27.1"
+    "swagger-editor-dist": "^4.14.6"
   },
   "devDependencies": {
     "electron": "^37.3.1",


### PR DESCRIPTION
## Summary
- switch app to Swagger Editor for editing specs
- allow passing a spec file via CLI to open in the editor
- set main window title to "OpenAPI Desktop"
- show build artifact locations after make targets complete

## Testing
- `npm test`
- `docker build -t openapi-desktop-builder .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68aef003e64c8324a9d7fa55c4125a70